### PR TITLE
import vue-html2-canvas

### DIFF
--- a/plugins/vue-html2-canvas.js
+++ b/plugins/vue-html2-canvas.js
@@ -1,0 +1,4 @@
+import Vue from "vue";
+import VueHtml2Canvas from "vue-html2canvas";
+
+Vue.use(VueHtml2Canvas);


### PR DESCRIPTION
## 背景
- vue-html2-canvasをnuxtで読み込みたい
## 手順
1. `% yarn add vue-html2canvas`
2. `plugins`に以下を記述
```js
import Vue from 'vue';
import VueHtml2Canvas from 'vue-html2canvas';

Vue.use(VueHtml2Canvas);
```
3. `nuxt.config.js`のplauginsを指定．